### PR TITLE
Optimization for confirmed blocks on syncing

### DIFF
--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -460,7 +460,8 @@ func (e *EventTracker) getLogsForBlocks(fromBlock, toBlock uint64) error {
 	return nil
 }
 
-// getLogsForBlocksInBatches is a method of the EventTracker struct that is responsible for getting logs for blocks in batches.
+// getLogsForBlocksInBatches is a method of the EventTracker struct
+// that is responsible for getting logs for blocks in batches.
 //
 // Example Usage:
 //

--- a/tracker/tracker_block_container.go
+++ b/tracker/tracker_block_container.go
@@ -64,6 +64,13 @@ func (t *TrackerBlockContainer) LastProcessedBlockLocked() uint64 {
 	return t.lastProcessedConfirmedBlock
 }
 
+// UpdateLastProcessedBlockLocked updates the number of last processed block for logs
+// Function assumes that the write lock is already acquired before accessing
+// the lastProcessedConfirmedBlock field
+func (t *TrackerBlockContainer) UpdateLastProcessedBlockLocked(lastProcessed uint64) {
+	t.lastProcessedConfirmedBlock = lastProcessed
+}
+
 // LastCachedBlock returns the block number of the last cached block for processing
 //
 // Example Usage:


### PR DESCRIPTION
Added optimization when out of sync or getting new state on reorg, where, if we have confirmed blocks that we are trying to sync, we will get their logs in batches, without the need to first get block by block in batches.

This optimizes the number of rpc calls to tracked chain.