### PR TITLE
Add chainID to AddLog

### DIFF
--- a/tracker/tracker_fuzz_test.go
+++ b/tracker/tracker_fuzz_test.go
@@ -75,8 +75,7 @@ func FuzzGetNewState(f *testing.F) {
 		}
 		providerMock.On("GetLogs", mock.Anything).Return(logs, nil)
 
-		testConfig := createTestTrackerConfig(t, data.NumBlockConfirmations, data.BatchSize, data.NumOfBlocksToReconcile)
-		testConfig.BlockProvider = providerMock
+		testConfig := createTestTrackerConfig(t, data.NumBlockConfirmations, data.BatchSize, data.NumOfBlocksToReconcile, providerMock)
 
 		eventTracker := &EventTracker{
 			config:         testConfig,

--- a/tracker/tracker_fuzz_test.go
+++ b/tracker/tracker_fuzz_test.go
@@ -75,7 +75,8 @@ func FuzzGetNewState(f *testing.F) {
 		}
 		providerMock.On("GetLogs", mock.Anything).Return(logs, nil)
 
-		testConfig := createTestTrackerConfig(t, data.NumBlockConfirmations, data.BatchSize, data.NumOfBlocksToReconcile, providerMock)
+		testConfig := createTestTrackerConfig(t, data.NumBlockConfirmations, data.BatchSize,
+			data.NumOfBlocksToReconcile, providerMock)
 
 		eventTracker := &EventTracker{
 			config:         testConfig,


### PR DESCRIPTION
This PR expands `AddLog` function called on event subscribers with chainID parameter.